### PR TITLE
Users can now have separate PRs per `tfupdate_path`.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -eu
 function subcommandTerraform {
   VERSION=$(tfupdate release latest hashicorp/terraform)
 
-  UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION}"
+  UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION} in ${TFUPDATE_PATH}"
   if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
     echo "A pull request already exists"
   elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
@@ -40,7 +40,7 @@ function subcommandTerraform {
 function subcommandProvider {
   VERSION=$(tfupdate release latest terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME})
 
-  UPDATE_MESSAGE="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${VERSION}"
+  UPDATE_MESSAGE="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${VERSION} in ${TFUPDATE_PATH}"
   if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
     echo "A pull request already exists"
   elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,24 @@
 
 set -eu
 
+function branchForTerraform {
+  STR=tfupdate
+  if [ $TFUPDATE_PATH != "." ]; then
+    # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
+    STR="$STR/$(echo $TFUPDATE_PATH | sed 's:^/*::' | sed 's:/*$::')"
+  fi
+  echo "${STR}/terraform-v${VERSION}"
+}
+
+function branchForProvider {
+  STR=tfupdate
+  if [ $TFUPDATE_PATH != "." ]; then
+    # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
+    STR="$STR/$(echo $TFUPDATE_PATH | sed 's:^/*::' | sed 's:/*$::')"
+  fi
+  echo "${STR}/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
+}
+
 function subcommandTerraform {
   VERSION=$(tfupdate release latest hashicorp/terraform)
 
@@ -11,7 +29,7 @@ function subcommandTerraform {
   elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
     echo "A pull request is already merged"
   else
-    git checkout -b update-terraform-to-v${VERSION} origin/${PR_BASE_BRANCH}
+    git checkout -b $(branchForTerraform) origin/${PR_BASE_BRANCH}
     tfupdate terraform -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
 
     if git add . && git diff --cached --exit-code --quiet; then
@@ -46,7 +64,7 @@ function subcommandProvider {
   elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
     echo "A pull request is already merged"
   else
-    git checkout -b update-terraform-provider-${TFUPDATE_PROVIDER_NAME}-to-v${VERSION} origin/${PR_BASE_BRANCH}
+    git checkout -b $(branchForProvider) origin/${PR_BASE_BRANCH}
     tfupdate provider ${TFUPDATE_PROVIDER_NAME} -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
     if git add . && git diff --cached --exit-code --quiet; then
       echo "No changes"


### PR DESCRIPTION
Users can now have separate PRs per `tfupdate_path`.

## 1. Update PR title

Before:

```
[tfupdate] Update terraform to v1.6.2
[tfupdate] Update terraform-provider-aws to v5.19.0
```

After:

```
[tfupdate] Update terraform to v1.6.2
[tfupdate] Update terraform-provider-aws to v5.19.0
or
[tfupdate] Update terraform to v1.6.2 in ${tfupdate_path}
[tfupdate] Update terraform-provider-aws to v5.19.0 in ${tfupdate_path}
```

## 2. Update PR branch

Before:

```
update-terraform-to-v1.6.2
update-terraform-provider-aws-to-v5.19.0
```

After:

```
tfupdate/terraform-v1.6.2
tfupdate/terraform-provider/aws-v5.19.0
or
tfupdate/${tfupdate_path}/terraform-v1.6.2
tfupdate/${tfupdate_path}/terraform-provider/aws-v5.19.0
```