### PR TITLE
Improve README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ permissions:
 |------|----------|---------|-------------|
 | `github_token` | Yes | — | GitHub Token |
 | `tfupdate_subcommand` | Yes | — | Subcommand to execute (`terraform` or `provider`) |
-| `tfupdate_path` | Yes | `.` | A path provided to tfupdate |
+| `tfupdate_path` | No | `.` | A path provided to tfupdate |
 | `tfupdate_options` | No | `-r` | Options provided to tfupdate |
 | `tfupdate_provider_name` | No | — | Provider name (required when subcommand is `provider`) |
 | `update_tfenv_version_files` | No | `false` | Whether to update `.terraform-version` files (only for `terraform` subcommand) |
 | `pr_base_branch` | No | Trigger branch | The base branch of a Pull Request |
-| `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR |
+| `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR (no spaces around the comma) |
 
 ## Subcommands
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,85 @@
 # tfupdate-github-actions
 
-Github Actions for [tfupdate](https://github.com/minamijoyo/tfupdate).
+<p>
+  <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="./README_ja.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>
+</p>
 
-This action runs tfupdate, and create Pull Requests if new versions of terraform or providers are found.
+GitHub Actions for [tfupdate](https://github.com/minamijoyo/tfupdate).
 
-:bulb: This repository is a fork from [daisaru11/tfupdate-github-actions](https://github.com/daisaru11/tfupdate-github-actions). See [v1.0.0...HEAD](https://github.com/masutaka/tfupdate-github-actions/compare/v1.0.0...HEAD) for the differences.
+This action runs tfupdate to check for new versions of Terraform or providers, and automatically creates a Pull Request if updates are found.
 
-## Usage
+> [!NOTE]
+> This repository is a fork from [daisaru11/tfupdate-github-actions](https://github.com/daisaru11/tfupdate-github-actions). See [v1.0.0...HEAD](https://github.com/masutaka/tfupdate-github-actions/compare/v1.0.0...HEAD) for the differences.
+
+## Prerequisites
+
+The workflow job requires the following permissions:
+
+```yaml
+permissions:
+  contents: write       # To push a new branch
+  pull-requests: write  # To create a pull request
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `github_token` | Yes | — | GitHub Token |
+| `tfupdate_subcommand` | Yes | — | Subcommand to execute (`terraform` or `provider`) |
+| `tfupdate_path` | Yes | `.` | A path provided to tfupdate |
+| `tfupdate_options` | No | `-r` | Options provided to tfupdate |
+| `tfupdate_provider_name` | No | — | Provider name (required when subcommand is `provider`) |
+| `update_tfenv_version_files` | No | `false` | Whether to update `.terraform-version` files (only for `terraform` subcommand) |
+| `pr_base_branch` | No | Trigger branch | The base branch of a Pull Request |
+| `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR |
+
+## Subcommands
+
+### `terraform`
+
+Fetches the latest Terraform version and updates version constraints in `.tf` files. If `update_tfenv_version_files` is enabled, `.terraform-version` files are also updated.
+
+```yaml
+- uses: masutaka/tfupdate-github-actions@v2.1.0
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    tfupdate_subcommand: terraform
+    tfupdate_path: './workspaces'
+    assignees: 'alice'
+```
+
+### `provider`
+
+Fetches the latest version of the specified Terraform provider and updates version constraints. `tfupdate_provider_name` is required for this subcommand.
+
+```yaml
+- uses: masutaka/tfupdate-github-actions@v2.1.0
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    tfupdate_subcommand: provider
+    tfupdate_path: './workspaces'
+    tfupdate_provider_name: aws
+    assignees: 'alice,bob'
+```
+
+## Branch naming and PR deduplication
+
+### Branch naming
+
+Branches are created with the following patterns:
+
+- `terraform`: `tfupdate/[path/]terraform-v{VERSION}`
+- `provider`: `tfupdate/[path/]terraform-provider/{name}-v{VERSION}`
+
+When `tfupdate_path` is `.`, the path segment is omitted.
+
+### PR deduplication
+
+Before creating a PR, the action checks whether a PR with the same title already exists (open or merged). If a matching PR is found, the action skips creating a new one.
+
+## Full example
 
 ```yaml
 on:

--- a/README_ja.md
+++ b/README_ja.md
@@ -28,12 +28,12 @@ permissions:
 |------|------|-----------|------|
 | `github_token` | Yes | — | GitHub Token |
 | `tfupdate_subcommand` | Yes | — | 実行するサブコマンド (`terraform` or `provider`) |
-| `tfupdate_path` | Yes | `.` | tfupdate に渡すパス |
+| `tfupdate_path` | No | `.` | tfupdate に渡すパス |
 | `tfupdate_options` | No | `-r` | tfupdate に渡すオプション |
 | `tfupdate_provider_name` | No | — | プロバイダー名 (サブコマンドが `provider` の場合は必須) |
 | `update_tfenv_version_files` | No | `false` | `.terraform-version` ファイルも更新するか (`terraform` サブコマンド専用) |
 | `pr_base_branch` | No | トリガーブランチ | Pull Request のベースブランチ |
-| `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト |
+| `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト (カンマの前後にスペース不可) |
 
 ## サブコマンド
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,125 @@
+# tfupdate-github-actions
+
+<p>
+  <a href="./README.md"><img alt="README in English" src="https://img.shields.io/badge/English-d9d9d9"></a>
+  <a href="./README_ja.md"><img alt="日本語のREADME" src="https://img.shields.io/badge/日本語-d9d9d9"></a>
+</p>
+
+[tfupdate](https://github.com/minamijoyo/tfupdate) 用の GitHub Actions です。
+
+このアクションは tfupdate を実行し、Terraform 本体やプロバイダーの新バージョンが見つかった場合に Pull Request を自動作成します。
+
+> [!NOTE]
+> このリポジトリは [daisaru11/tfupdate-github-actions](https://github.com/daisaru11/tfupdate-github-actions) のフォークです。差分は [v1.0.0...HEAD](https://github.com/masutaka/tfupdate-github-actions/compare/v1.0.0...HEAD) を参照してください。
+
+## 前提条件
+
+ワークフロージョブに以下の権限が必要です:
+
+```yaml
+permissions:
+  contents: write       # 新しいブランチの push 用
+  pull-requests: write  # Pull Request の作成用
+```
+
+## 入力パラメータ
+
+| 名前 | 必須 | デフォルト | 説明 |
+|------|------|-----------|------|
+| `github_token` | Yes | — | GitHub Token |
+| `tfupdate_subcommand` | Yes | — | 実行するサブコマンド (`terraform` or `provider`) |
+| `tfupdate_path` | Yes | `.` | tfupdate に渡すパス |
+| `tfupdate_options` | No | `-r` | tfupdate に渡すオプション |
+| `tfupdate_provider_name` | No | — | プロバイダー名 (サブコマンドが `provider` の場合は必須) |
+| `update_tfenv_version_files` | No | `false` | `.terraform-version` ファイルも更新するか (`terraform` サブコマンド専用) |
+| `pr_base_branch` | No | トリガーブランチ | Pull Request のベースブランチ |
+| `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト |
+
+## サブコマンド
+
+### `terraform`
+
+最新の Terraform バージョンを取得し、`.tf` ファイル内のバージョン制約を更新します。`update_tfenv_version_files` を有効にすると、`.terraform-version` ファイルも更新されます。
+
+```yaml
+- uses: masutaka/tfupdate-github-actions@v2.1.0
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    tfupdate_subcommand: terraform
+    tfupdate_path: './workspaces'
+    assignees: 'alice'
+```
+
+### `provider`
+
+指定された Terraform プロバイダーの最新バージョンを取得し、バージョン制約を更新します。このサブコマンドでは `tfupdate_provider_name` が必須です。
+
+```yaml
+- uses: masutaka/tfupdate-github-actions@v2.1.0
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    tfupdate_subcommand: provider
+    tfupdate_path: './workspaces'
+    tfupdate_provider_name: aws
+    assignees: 'alice,bob'
+```
+
+## ブランチ命名と PR 重複防止
+
+### ブランチ命名
+
+以下のパターンでブランチが作成されます:
+
+- `terraform`: `tfupdate/[path/]terraform-v{VERSION}`
+- `provider`: `tfupdate/[path/]terraform-provider/{name}-v{VERSION}`
+
+`tfupdate_path` が `.` の場合、パス部分は省略されます。
+
+### PR 重複防止
+
+PR 作成前に、同じタイトルの PR が既に存在するか (open または merged) を確認します。一致する PR が見つかった場合、新しい PR の作成はスキップされます。
+
+## 使用例
+
+```yaml
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  tfupdate_terraform:
+    runs-on: ubuntu-latest
+    name: Update terraform versions
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v6
+    - name: Create terraform update PR if need
+      uses: masutaka/tfupdate-github-actions@v2.1.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tfupdate_subcommand: terraform
+        tfupdate_path: './workspaces'
+        assignees: 'alice'
+  tfupdate_provider:
+    runs-on: ubuntu-latest
+    name: Update terraform provider versions
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v6
+    - name: Create terraform provider update PR if need
+      uses: masutaka/tfupdate-github-actions@v2.1.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        tfupdate_subcommand: provider
+        tfupdate_path: './workspaces'
+        tfupdate_provider_name: aws
+        assignees: 'alice,bob'
+```
+
+作成される Pull Request の例は[こちら](https://github.com/daisaru11/tfupdate-github-actions-example/pulls)で確認できます。

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   tfupdate_path:
     description: 'A path provided to tfupdate'
-    required: true
+    required: false
     default: '.'
   tfupdate_options:
     description: 'Options provided to tfupdate'


### PR DESCRIPTION
- closes https://github.com/masutaka/tfupdate-github-actions/issues/6

## Summary

- Expand README.md with comprehensive documentation: prerequisites, input parameters table, subcommand details, branch naming, and PR deduplication
- Add README_ja.md as a Japanese translation
- Add language-switching badges to both files
- Fix `tfupdate_path` metadata: change `required: true` to `false` in action.yml since it has a default value
- Add no-spaces constraint note for `assignees` input
