### PR TITLE
Support .tool-versions file for terraform version management

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ permissions:
 | `tfupdate_options` | No | `-r` | Options provided to tfupdate |
 | `tfupdate_provider_name` | No | — | Provider name (required when subcommand is `provider`) |
 | `update_tfenv_version_files` | No | `false` | Whether to update `.terraform-version` files (only for `terraform` subcommand) |
+| `update_tool_versions_files` | No | `false` | Whether to update `.tool-versions` files (only for `terraform` subcommand) |
 | `pr_base_branch` | No | Trigger branch | The base branch of a Pull Request |
 | `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR (no spaces around the comma) |
 
@@ -39,7 +40,12 @@ permissions:
 
 ### `terraform`
 
-Fetches the latest Terraform version and updates version constraints in `.tf` files. If `update_tfenv_version_files` is enabled, `.terraform-version` files are also updated.
+Fetches the latest Terraform version and updates version constraints in `.tf` files.
+
+- `update_tfenv_version_files`: also updates `.terraform-version` files
+- `update_tool_versions_files`: also updates the `terraform` entry in `.tool-versions` files
+
+These version file updates target files in the same directory as changed `.tf` files and at the repository root.
 
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.1.0

--- a/README_ja.md
+++ b/README_ja.md
@@ -32,6 +32,7 @@ permissions:
 | `tfupdate_options` | No | `-r` | tfupdate に渡すオプション |
 | `tfupdate_provider_name` | No | — | プロバイダー名 (サブコマンドが `provider` の場合は必須) |
 | `update_tfenv_version_files` | No | `false` | `.terraform-version` ファイルも更新するか (`terraform` サブコマンド専用) |
+| `update_tool_versions_files` | No | `false` | `.tool-versions` ファイルも更新するか (`terraform` サブコマンド専用) |
 | `pr_base_branch` | No | トリガーブランチ | Pull Request のベースブランチ |
 | `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト (カンマの前後にスペース不可) |
 
@@ -39,7 +40,12 @@ permissions:
 
 ### `terraform`
 
-最新の Terraform バージョンを取得し、`.tf` ファイル内のバージョン制約を更新します。`update_tfenv_version_files` を有効にすると、`.terraform-version` ファイルも更新されます。
+最新の Terraform バージョンを取得し、`.tf` ファイル内のバージョン制約を更新します。
+
+- `update_tfenv_version_files`: `.terraform-version` ファイルも更新
+- `update_tool_versions_files`: `.tool-versions` ファイル内の `terraform` エントリも更新
+
+これらのバージョンファイルの更新対象は、変更された `.tf` ファイルと同じディレクトリ、およびリポジトリルートに存在するファイルのみです。
 
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.1.0

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,11 @@ inputs:
     required: false
   update_tfenv_version_files:
     description: 'Whether of not to update .terraform-version files (used if `terraform` is given as the subcommand)'
-    default: false
+    default: 'false'
+    required: false
+  update_tool_versions_files:
+    description: 'Whether or not to update .tool-versions files (used if `terraform` is given as the subcommand)'
+    default: 'false'
     required: false
   github_token:
     description: 'Github Token'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,21 @@ function subcommandTerraform {
         git add .
       fi
 
+      if [ "${UPDATE_TOOL_VERSIONS_FILES}" == "1" ]; then
+        for UPDATED_HCL in $(git diff --cached --name-only); do
+          TOOL_VERSIONS_FILE="$(dirname $UPDATED_HCL)/.tool-versions"
+          if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
+            sed "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE" > "$TOOL_VERSIONS_FILE.tmp"
+            mv "$TOOL_VERSIONS_FILE.tmp" "$TOOL_VERSIONS_FILE"
+          fi
+        done
+        if [ -f ".tool-versions" ] && grep -q '^terraform ' ".tool-versions"; then
+          sed "s/^terraform .*/terraform ${VERSION}/" ".tool-versions" > ".tool-versions.tmp"
+          mv ".tool-versions.tmp" ".tool-versions"
+        fi
+        git add .
+      fi
+
       git commit -m "$UPDATE_MESSAGE"
       PR_BODY="For details see: https://github.com/hashicorp/terraform/releases"
       if [ -n "$ASSIGNEES" ]; then
@@ -115,6 +130,11 @@ fi
 UPDATE_TFENV_VERSION_FILES=0
 if [ "${INPUT_UPDATE_TFENV_VERSION_FILES}" == "1" ] || [ "${INPUT_UPDATE_TFENV_VERSION_FILES}" == "true" ]; then
   UPDATE_TFENV_VERSION_FILES=1
+fi
+
+UPDATE_TOOL_VERSIONS_FILES=0
+if [ "${INPUT_UPDATE_TOOL_VERSIONS_FILES}" == "1" ] || [ "${INPUT_UPDATE_TOOL_VERSIONS_FILES}" == "true" ]; then
+  UPDATE_TOOL_VERSIONS_FILES=1
 fi
 
 PR_BASE_BRANCH="${GITHUB_REF##*/}"


### PR DESCRIPTION
- closes https://github.com/masutaka/tfupdate-github-actions/issues/4

## Summary

Add `update_tool_versions_files` input parameter to support updating `.tool-versions` files (asdf/mise format) when the `terraform` subcommand bumps the Terraform version.

- Add new `update_tool_versions_files` input (default: `false`) to `action.yml`
- Implement `.tool-versions` update logic in `entrypoint.sh` using `grep` + `sed` with temp file for portability
- Only update existing `terraform` entries — never add new lines
- Update scope: `.tool-versions` in the same directory as changed `.tf` files and at the repository root
- Fix `default` value type for `update_tfenv_version_files` (`false` → `'false'`) per GitHub Actions metadata spec
- Document the new parameter and update scope constraint in both READMEs