### PR TITLE
Replace Docker-based action with composite action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM minamijoyo/tfupdate
-
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ permissions:
 | `update_tfenv_version_files` | No | `false` | Whether to update `.terraform-version` files (only for `terraform` subcommand) |
 | `update_tool_versions_files` | No | `false` | Whether to update `.tool-versions` files (only for `terraform` subcommand) |
 | `pr_base_branch` | No | Trigger branch | The base branch of a Pull Request |
-| `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR (no spaces around the comma) |
+| `assignees` | No | — | Comma-separated list of GitHub handles to assign to the PR |
 
 ## Subcommands
 
@@ -83,7 +83,7 @@ When `tfupdate_path` is `.`, the path segment is omitted.
 
 ### PR deduplication
 
-Before creating a PR, the action checks whether a PR with the same title already exists (open or merged). If a matching PR is found, the action skips creating a new one.
+Before creating a PR, the action checks whether a PR for the same branch already exists (open or merged). If a matching PR is found, the action skips creating a new one.
 
 ## Full example
 
@@ -94,7 +94,7 @@ on:
 
 jobs:
   tfupdate_terraform:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Update terraform versions
     timeout-minutes: 5
     permissions:
@@ -110,7 +110,7 @@ jobs:
         tfupdate_path: './workspaces'
         assignees: 'alice'
   tfupdate_provider:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Update terraform provider versions
     timeout-minutes: 5
     permissions:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ permissions:
 
 | Name | Required | Default | Description |
 |------|----------|---------|-------------|
-| `github_token` | Yes | — | GitHub Token |
+| `github_token` | No | `github.token` | GitHub Token |
 | `tfupdate_subcommand` | Yes | — | Subcommand to execute (`terraform` or `provider`) |
 | `tfupdate_path` | No | `.` | A path provided to tfupdate |
 | `tfupdate_options` | No | `-r` | Options provided to tfupdate |
@@ -50,7 +50,6 @@ These version file updates target files in the same directory as changed `.tf` f
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.2.0
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
     tfupdate_subcommand: terraform
     tfupdate_path: './workspaces'
     assignees: 'alice'
@@ -63,7 +62,6 @@ Fetches the latest version of the specified Terraform provider and updates versi
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.2.0
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
     tfupdate_subcommand: provider
     tfupdate_path: './workspaces'
     tfupdate_provider_name: aws
@@ -105,7 +103,6 @@ jobs:
     - name: Create terraform update PR if need
       uses: masutaka/tfupdate-github-actions@v2.2.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         tfupdate_subcommand: terraform
         tfupdate_path: './workspaces'
         assignees: 'alice'
@@ -121,7 +118,6 @@ jobs:
     - name: Create terraform provider update PR if need
       uses: masutaka/tfupdate-github-actions@v2.2.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         tfupdate_subcommand: provider
         tfupdate_path: './workspaces'
         tfupdate_provider_name: aws

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,7 +26,7 @@ permissions:
 
 | 名前 | 必須 | デフォルト | 説明 |
 |------|------|-----------|------|
-| `github_token` | Yes | — | GitHub Token |
+| `github_token` | No | `github.token` | GitHub Token |
 | `tfupdate_subcommand` | Yes | — | 実行するサブコマンド (`terraform` or `provider`) |
 | `tfupdate_path` | No | `.` | tfupdate に渡すパス |
 | `tfupdate_options` | No | `-r` | tfupdate に渡すオプション |
@@ -50,7 +50,6 @@ permissions:
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.2.0
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
     tfupdate_subcommand: terraform
     tfupdate_path: './workspaces'
     assignees: 'alice'
@@ -63,7 +62,6 @@ permissions:
 ```yaml
 - uses: masutaka/tfupdate-github-actions@v2.2.0
   with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
     tfupdate_subcommand: provider
     tfupdate_path: './workspaces'
     tfupdate_provider_name: aws
@@ -105,7 +103,6 @@ jobs:
     - name: Create terraform update PR if need
       uses: masutaka/tfupdate-github-actions@v2.2.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         tfupdate_subcommand: terraform
         tfupdate_path: './workspaces'
         assignees: 'alice'
@@ -121,7 +118,6 @@ jobs:
     - name: Create terraform provider update PR if need
       uses: masutaka/tfupdate-github-actions@v2.2.0
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
         tfupdate_subcommand: provider
         tfupdate_path: './workspaces'
         tfupdate_provider_name: aws

--- a/README_ja.md
+++ b/README_ja.md
@@ -34,7 +34,7 @@ permissions:
 | `update_tfenv_version_files` | No | `false` | `.terraform-version` ファイルも更新するか (`terraform` サブコマンド専用) |
 | `update_tool_versions_files` | No | `false` | `.tool-versions` ファイルも更新するか (`terraform` サブコマンド専用) |
 | `pr_base_branch` | No | トリガーブランチ | Pull Request のベースブランチ |
-| `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト (カンマの前後にスペース不可) |
+| `assignees` | No | — | PR にアサインする GitHub ハンドルのカンマ区切りリスト |
 
 ## サブコマンド
 
@@ -83,7 +83,7 @@ permissions:
 
 ### PR 重複防止
 
-PR 作成前に、同じタイトルの PR が既に存在するか (open または merged) を確認します。一致する PR が見つかった場合、新しい PR の作成はスキップされます。
+PR 作成前に、同じブランチの PR が既に存在するか (open または merged) を確認します。一致する PR が見つかった場合、新しい PR の作成はスキップされます。
 
 ## 使用例
 
@@ -94,7 +94,7 @@ on:
 
 jobs:
   tfupdate_terraform:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Update terraform versions
     timeout-minutes: 5
     permissions:
@@ -110,7 +110,7 @@ jobs:
         tfupdate_path: './workspaces'
         assignees: 'alice'
   tfupdate_provider:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     name: Update terraform provider versions
     timeout-minutes: 5
     permissions:

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,8 @@ inputs:
     required: false
   github_token:
     description: 'Github Token'
-    required: true
+    required: false
+    default: ${{ github.token }}
   pr_base_branch:
     description: 'The base branch of a Pull Request'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,33 @@ inputs:
     description: 'A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request'
     required: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "composite"
+  steps:
+    - name: Install tfupdate
+      env:
+        TFUPDATE_VERSION: v0.9.3
+        TFUPDATE_SHA256: dfdc45648bb5e3efd4fb6e6e03fb672254041640116e2255380b5dfe7c01ff3a
+      run: |
+        curl -fL --output "$RUNNER_TEMP/tfupdate.tar.gz" "https://github.com/minamijoyo/tfupdate/releases/download/${TFUPDATE_VERSION}/tfupdate_${TFUPDATE_VERSION#v}_linux_amd64.tar.gz"
+        echo "${TFUPDATE_SHA256} $RUNNER_TEMP/tfupdate.tar.gz" | sha256sum -c -
+        tar xz -C "$RUNNER_TEMP" -f "$RUNNER_TEMP/tfupdate.tar.gz" tfupdate
+        echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+        export PATH="$RUNNER_TEMP:$PATH"
+        tfupdate --version
+      shell: bash
+
+    - name: Run entrypoint
+      run: ${{ github.action_path }}/entrypoint.sh
+      shell: bash
+      env:
+        INPUT_TFUPDATE_SUBCOMMAND: ${{ inputs.tfupdate_subcommand }}
+        INPUT_TFUPDATE_PATH: ${{ inputs.tfupdate_path }}
+        INPUT_TFUPDATE_OPTIONS: ${{ inputs.tfupdate_options }}
+        INPUT_TFUPDATE_PROVIDER_NAME: ${{ inputs.tfupdate_provider_name }}
+        INPUT_UPDATE_TFENV_VERSION_FILES: ${{ inputs.update_tfenv_version_files }}
+        INPUT_UPDATE_TOOL_VERSIONS_FILES: ${{ inputs.update_tool_versions_files }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_PR_BASE_BRANCH: ${{ inputs.pr_base_branch }}
+        INPUT_ASSIGNEES: ${{ inputs.assignees }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        GH_REPO: ${{ github.repository }}

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: 'The base branch of a Pull Request'
     required: false
   assignees:
-    description: 'A comma-separated list (no spaces around the comma) of GitHub handles to assign to this pull request'
+    description: 'A comma-separated list of GitHub handles to assign to this pull request'
     required: false
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -42,10 +42,7 @@ runs:
       run: |
         curl -fL --output "$RUNNER_TEMP/tfupdate.tar.gz" "https://github.com/minamijoyo/tfupdate/releases/download/${TFUPDATE_VERSION}/tfupdate_${TFUPDATE_VERSION#v}_linux_amd64.tar.gz"
         echo "${TFUPDATE_SHA256} $RUNNER_TEMP/tfupdate.tar.gz" | sha256sum -c -
-        tar xz -C "$RUNNER_TEMP" -f "$RUNNER_TEMP/tfupdate.tar.gz" tfupdate
-        echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-        export PATH="$RUNNER_TEMP:$PATH"
-        tfupdate --version
+        tar xz -C /usr/local/bin -f "$RUNNER_TEMP/tfupdate.tar.gz" tfupdate
       shell: bash
 
     - name: Run entrypoint

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,18 @@ set -euo pipefail
 
 function branchForTerraform {
   STR=tfupdate
-  if [ $TFUPDATE_PATH != "." ]; then
+  if [ "$TFUPDATE_PATH" != "." ]; then
     # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo $TFUPDATE_PATH | sed 's:^/*::' | sed 's:/*$::')"
+    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::' | sed 's:/*$::')"
   fi
   echo "${STR}/terraform-v${VERSION}"
 }
 
 function branchForProvider {
   STR=tfupdate
-  if [ $TFUPDATE_PATH != "." ]; then
+  if [ "$TFUPDATE_PATH" != "." ]; then
     # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo $TFUPDATE_PATH | sed 's:^/*::' | sed 's:/*$::')"
+    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::' | sed 's:/*$::')"
   fi
   echo "${STR}/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
 }
@@ -159,9 +159,9 @@ else
   exit 1
 fi
 
-cd ${GITHUB_WORKSPACE}/
+cd "${GITHUB_WORKSPACE}/"
 
-git config --global --add safe.directory $GITHUB_WORKSPACE
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,12 +90,12 @@ function subcommandProvider {
       echo "No changes"
     else
       git commit -m "$UPDATE_MESSAGE"
-      PULL_REQUEST_BODY="For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
+      PR_BODY="For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
       git push origin HEAD
       if [ -n "$ASSIGNEES" ]; then
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PULL_REQUEST_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
       else
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PULL_REQUEST_BODY" --base "${PR_BASE_BRANCH}"
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}"
       fi
 
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,11 +12,13 @@ function branchPrefix {
 }
 
 function branchForTerraform {
-  echo "$(branchPrefix)/terraform-v${VERSION}"
+  local version="$1"
+  echo "$(branchPrefix)/terraform-v${version}"
 }
 
 function branchForProvider {
-  echo "$(branchPrefix)/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
+  local version="$1"
+  echo "$(branchPrefix)/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${version}"
 }
 
 function hasExistingPR {
@@ -29,29 +31,33 @@ function hasExistingPR {
 function commitAndCreatePR {
   local message="$1"
   local body="$2"
+  local base_branch="$3"
+  local assignees="$4"
 
   git commit -m "$message"
   git push origin HEAD
-  if [ -n "$ASSIGNEES" ]; then
-    gh pr create --title "$message" --body "$body" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
+  if [ -n "$assignees" ]; then
+    gh pr create --title "$message" --body "$body" --base "${base_branch}" --assignee "${assignees}"
   else
-    gh pr create --title "$message" --body "$body" --base "${PR_BASE_BRANCH}"
+    gh pr create --title "$message" --body "$body" --base "${base_branch}"
   fi
 }
 
 function subcommandTerraform {
-  VERSION=$(tfupdate release latest hashicorp/terraform)
+  local version
+  version=$(tfupdate release latest hashicorp/terraform)
 
-  VERSION_BRANCH=$(branchForTerraform)
-  UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION} in ${TFUPDATE_PATH}"
+  local version_branch
+  version_branch=$(branchForTerraform "$version")
+  local update_message="[tfupdate] Update terraform to v${version} in ${TFUPDATE_PATH}"
 
-  if hasExistingPR "${VERSION_BRANCH}"; then
-    echo "A pull request already exists for branch ${VERSION_BRANCH}"
+  if hasExistingPR "${version_branch}"; then
+    echo "A pull request already exists for branch ${version_branch}"
     return
   fi
 
-  git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
-  tfupdate terraform -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
+  git checkout -b "${version_branch}" "origin/${PR_BASE_BRANCH}"
+  tfupdate terraform -v "${version}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
 
   git add .
   if git diff --cached --exit-code --quiet; then
@@ -63,11 +69,11 @@ function subcommandTerraform {
     for UPDATED_HCL in $(git diff --cached --name-only); do
       TFENV_VERSION_FILE="$(dirname "$UPDATED_HCL")/.terraform-version"
       if [ -f "$TFENV_VERSION_FILE" ]; then
-        echo "$VERSION" > "$TFENV_VERSION_FILE"
+        echo "$version" > "$TFENV_VERSION_FILE"
       fi
     done
     if [ -f ".terraform-version" ]; then
-      echo "$VERSION" > ".terraform-version"
+      echo "$version" > ".terraform-version"
     fi
     git add .
   fi
@@ -76,31 +82,33 @@ function subcommandTerraform {
     for UPDATED_HCL in $(git diff --cached --name-only); do
       TOOL_VERSIONS_FILE="$(dirname "$UPDATED_HCL")/.tool-versions"
       if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
-        sed -i "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE"
+        sed -i "s/^terraform .*/terraform ${version}/" "$TOOL_VERSIONS_FILE"
       fi
     done
     if [ -f ".tool-versions" ] && grep -q '^terraform ' ".tool-versions"; then
-      sed -i "s/^terraform .*/terraform ${VERSION}/" ".tool-versions"
+      sed -i "s/^terraform .*/terraform ${version}/" ".tool-versions"
     fi
     git add .
   fi
 
-  commitAndCreatePR "$UPDATE_MESSAGE" "For details see: https://github.com/hashicorp/terraform/releases"
+  commitAndCreatePR "$update_message" "For details see: https://github.com/hashicorp/terraform/releases" "$PR_BASE_BRANCH" "$ASSIGNEES"
 }
 
 function subcommandProvider {
-  VERSION=$(tfupdate release latest terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME})
+  local version
+  version=$(tfupdate release latest terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME})
 
-  VERSION_BRANCH=$(branchForProvider)
-  UPDATE_MESSAGE="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${VERSION} in ${TFUPDATE_PATH}"
+  local version_branch
+  version_branch=$(branchForProvider "$version")
+  local update_message="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${version} in ${TFUPDATE_PATH}"
 
-  if hasExistingPR "${VERSION_BRANCH}"; then
-    echo "A pull request already exists for branch ${VERSION_BRANCH}"
+  if hasExistingPR "${version_branch}"; then
+    echo "A pull request already exists for branch ${version_branch}"
     return
   fi
 
-  git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
-  tfupdate provider "${TFUPDATE_PROVIDER_NAME}" -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
+  git checkout -b "${version_branch}" "origin/${PR_BASE_BRANCH}"
+  tfupdate provider "${TFUPDATE_PROVIDER_NAME}" -v "${version}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
 
   git add .
   if git diff --cached --exit-code --quiet; then
@@ -108,7 +116,7 @@ function subcommandProvider {
     return
   fi
 
-  commitAndCreatePR "$UPDATE_MESSAGE" "For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
+  commitAndCreatePR "$update_message" "For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases" "$PR_BASE_BRANCH" "$ASSIGNEES"
 }
 
 TFUPDATE_SUBCOMMAND=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,22 +2,41 @@
 
 set -euo pipefail
 
-function branchForTerraform {
-  STR=tfupdate
+function branchPrefix {
+  local prefix=tfupdate
   if [ "$TFUPDATE_PATH" != "." ]; then
     # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::;s:/*$::')"
+    prefix="${prefix}/$(echo "$TFUPDATE_PATH" | sed 's:^/*::;s:/*$::')"
   fi
-  echo "${STR}/terraform-v${VERSION}"
+  echo "$prefix"
+}
+
+function branchForTerraform {
+  echo "$(branchPrefix)/terraform-v${VERSION}"
 }
 
 function branchForProvider {
-  STR=tfupdate
-  if [ "$TFUPDATE_PATH" != "." ]; then
-    # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::;s:/*$::')"
+  echo "$(branchPrefix)/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
+}
+
+function hasExistingPR {
+  local branch="$1"
+  local pr_count
+  pr_count="$(gh pr list --state all --head "${branch}" --json number --jq 'length')"
+  [ "$pr_count" -ne 0 ]
+}
+
+function commitAndCreatePR {
+  local message="$1"
+  local body="$2"
+
+  git commit -m "$message"
+  git push origin HEAD
+  if [ -n "$ASSIGNEES" ]; then
+    gh pr create --title "$message" --body "$body" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
+  else
+    gh pr create --title "$message" --body "$body" --base "${PR_BASE_BRANCH}"
   fi
-  echo "${STR}/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
 }
 
 function subcommandTerraform {
@@ -25,53 +44,48 @@ function subcommandTerraform {
 
   VERSION_BRANCH=$(branchForTerraform)
   UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION} in ${TFUPDATE_PATH}"
-  PR_COUNT="$(gh pr list --state all --head "${VERSION_BRANCH}" --json number --jq 'length')"
-  if [ "$PR_COUNT" -ne 0 ]; then
+
+  if hasExistingPR "${VERSION_BRANCH}"; then
     echo "A pull request already exists for branch ${VERSION_BRANCH}"
-  else
-    git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
-    tfupdate terraform -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
-
-    git add .
-    if git diff --cached --exit-code --quiet; then
-      echo "No changes"
-    else
-      if [ "${UPDATE_TFENV_VERSION_FILES}" == "1" ]; then
-        for UPDATED_HCL in $(git diff --cached --name-only); do
-          TFENV_VERSION_FILE="$(dirname "$UPDATED_HCL")/.terraform-version"
-          if [ -f "$TFENV_VERSION_FILE" ]; then
-            echo "$VERSION" > "$TFENV_VERSION_FILE"
-          fi
-        done
-        if [ -f ".terraform-version" ]; then
-          echo "$VERSION" > ".terraform-version"
-        fi
-        git add .
-      fi
-
-      if [ "${UPDATE_TOOL_VERSIONS_FILES}" == "1" ]; then
-        for UPDATED_HCL in $(git diff --cached --name-only); do
-          TOOL_VERSIONS_FILE="$(dirname "$UPDATED_HCL")/.tool-versions"
-          if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
-            sed -i "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE"
-          fi
-        done
-        if [ -f ".tool-versions" ] && grep -q '^terraform ' ".tool-versions"; then
-          sed -i "s/^terraform .*/terraform ${VERSION}/" ".tool-versions"
-        fi
-        git add .
-      fi
-
-      git commit -m "$UPDATE_MESSAGE"
-      PR_BODY="For details see: https://github.com/hashicorp/terraform/releases"
-      git push origin HEAD
-      if [ -n "$ASSIGNEES" ]; then
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
-      else
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}"
-      fi
-    fi
+    return
   fi
+
+  git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
+  tfupdate terraform -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
+
+  git add .
+  if git diff --cached --exit-code --quiet; then
+    echo "No changes"
+    return
+  fi
+
+  if [ "${UPDATE_TFENV_VERSION_FILES}" == "1" ]; then
+    for UPDATED_HCL in $(git diff --cached --name-only); do
+      TFENV_VERSION_FILE="$(dirname "$UPDATED_HCL")/.terraform-version"
+      if [ -f "$TFENV_VERSION_FILE" ]; then
+        echo "$VERSION" > "$TFENV_VERSION_FILE"
+      fi
+    done
+    if [ -f ".terraform-version" ]; then
+      echo "$VERSION" > ".terraform-version"
+    fi
+    git add .
+  fi
+
+  if [ "${UPDATE_TOOL_VERSIONS_FILES}" == "1" ]; then
+    for UPDATED_HCL in $(git diff --cached --name-only); do
+      TOOL_VERSIONS_FILE="$(dirname "$UPDATED_HCL")/.tool-versions"
+      if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
+        sed -i "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE"
+      fi
+    done
+    if [ -f ".tool-versions" ] && grep -q '^terraform ' ".tool-versions"; then
+      sed -i "s/^terraform .*/terraform ${VERSION}/" ".tool-versions"
+    fi
+    git add .
+  fi
+
+  commitAndCreatePR "$UPDATE_MESSAGE" "For details see: https://github.com/hashicorp/terraform/releases"
 }
 
 function subcommandProvider {
@@ -79,26 +93,22 @@ function subcommandProvider {
 
   VERSION_BRANCH=$(branchForProvider)
   UPDATE_MESSAGE="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${VERSION} in ${TFUPDATE_PATH}"
-  PR_COUNT="$(gh pr list --state all --head "${VERSION_BRANCH}" --json number --jq 'length')"
-  if [ "$PR_COUNT" -ne 0 ]; then
+
+  if hasExistingPR "${VERSION_BRANCH}"; then
     echo "A pull request already exists for branch ${VERSION_BRANCH}"
-  else
-    git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
-    tfupdate provider "${TFUPDATE_PROVIDER_NAME}" -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
-    git add .
-    if git diff --cached --exit-code --quiet; then
-      echo "No changes"
-    else
-      git commit -m "$UPDATE_MESSAGE"
-      PR_BODY="For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
-      git push origin HEAD
-      if [ -n "$ASSIGNEES" ]; then
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
-      else
-        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}"
-      fi
-    fi
+    return
   fi
+
+  git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
+  tfupdate provider "${TFUPDATE_PROVIDER_NAME}" -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
+
+  git add .
+  if git diff --cached --exit-code --quiet; then
+    echo "No changes"
+    return
+  fi
+
+  commitAndCreatePR "$UPDATE_MESSAGE" "For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
 }
 
 TFUPDATE_SUBCOMMAND=""
@@ -172,4 +182,3 @@ case "${TFUPDATE_SUBCOMMAND}" in
     exit 1
     ;;
 esac
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh -l
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 function branchForTerraform {
   STR=tfupdate
@@ -23,16 +23,17 @@ function branchForProvider {
 function subcommandTerraform {
   VERSION=$(tfupdate release latest hashicorp/terraform)
 
+  VERSION_BRANCH=$(branchForTerraform)
   UPDATE_MESSAGE="[tfupdate] Update terraform to v${VERSION} in ${TFUPDATE_PATH}"
-  if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-    echo "A pull request already exists"
-  elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-    echo "A pull request is already merged"
+  PR_COUNT="$(gh pr list --state all --head "${VERSION_BRANCH}" --json number --jq 'length')"
+  if [ "$PR_COUNT" -ne 0 ]; then
+    echo "A pull request already exists for branch ${VERSION_BRANCH}"
   else
-    git checkout -b $(branchForTerraform) origin/${PR_BASE_BRANCH}
+    git checkout -b "${VERSION_BRANCH}" origin/${PR_BASE_BRANCH}
     tfupdate terraform -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
 
-    if git add . && git diff --cached --exit-code --quiet; then
+    git add .
+    if git diff --cached --exit-code --quiet; then
       echo "No changes"
     else
       if [ "${UPDATE_TFENV_VERSION_FILES}" == "1" ]; then
@@ -65,10 +66,11 @@ function subcommandTerraform {
 
       git commit -m "$UPDATE_MESSAGE"
       PR_BODY="For details see: https://github.com/hashicorp/terraform/releases"
+      git push origin HEAD
       if [ -n "$ASSIGNEES" ]; then
-	git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PR_BODY" -b ${PR_BASE_BRANCH} -a ${ASSIGNEES}
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
       else
-	git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PR_BODY" -b ${PR_BASE_BRANCH}
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}"
       fi
     fi
   fi
@@ -77,23 +79,25 @@ function subcommandTerraform {
 function subcommandProvider {
   VERSION=$(tfupdate release latest terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME})
 
+  VERSION_BRANCH=$(branchForProvider)
   UPDATE_MESSAGE="[tfupdate] Update terraform-provider-${TFUPDATE_PROVIDER_NAME} to v${VERSION} in ${TFUPDATE_PATH}"
-  if hub pr list -s "open" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-    echo "A pull request already exists"
-  elif hub pr list -s "merged" -f "%t: %U%n" | grep -F "$UPDATE_MESSAGE"; then
-    echo "A pull request is already merged"
+  PR_COUNT="$(gh pr list --state all --head "${VERSION_BRANCH}" --json number --jq 'length')"
+  if [ "$PR_COUNT" -ne 0 ]; then
+    echo "A pull request already exists for branch ${VERSION_BRANCH}"
   else
-    git checkout -b $(branchForProvider) origin/${PR_BASE_BRANCH}
+    git checkout -b "${VERSION_BRANCH}" origin/${PR_BASE_BRANCH}
     tfupdate provider ${TFUPDATE_PROVIDER_NAME} -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
-    if git add . && git diff --cached --exit-code --quiet; then
+    git add .
+    if git diff --cached --exit-code --quiet; then
       echo "No changes"
     else
       git commit -m "$UPDATE_MESSAGE"
       PULL_REQUEST_BODY="For details see: https://github.com/terraform-providers/terraform-provider-${TFUPDATE_PROVIDER_NAME}/releases"
+      git push origin HEAD
       if [ -n "$ASSIGNEES" ]; then
-	git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PULL_REQUEST_BODY" -b ${PR_BASE_BRANCH} -a ${ASSIGNEES}
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PULL_REQUEST_BODY" --base "${PR_BASE_BRANCH}" --assignee "${ASSIGNEES}"
       else
-	git push origin HEAD && hub pull-request -m "$UPDATE_MESSAGE" -m "$PULL_REQUEST_BODY" -b ${PR_BASE_BRANCH}
+        gh pr create --title "$UPDATE_MESSAGE" --body "$PULL_REQUEST_BODY" --base "${PR_BASE_BRANCH}"
       fi
 
     fi
@@ -144,7 +148,7 @@ fi
 
 ASSIGNEES=""
 if [ "${INPUT_ASSIGNEES}" != "" ]; then
-  ASSIGNEES=${INPUT_ASSIGNEES}
+  ASSIGNEES=$(echo "${INPUT_ASSIGNEES}" | tr -d ' ')
 fi
 
 GITHUB_TOKEN=""
@@ -157,14 +161,13 @@ fi
 
 cd ${GITHUB_WORKSPACE}/
 
-export GITHUB_TOKEN
 git config --global --add safe.directory $GITHUB_WORKSPACE
 git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
 
 tfupdate --version
-hub --version
+gh --version
 
 case "${TFUPDATE_SUBCOMMAND}" in
   terraform)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ function branchForTerraform {
   STR=tfupdate
   if [ "$TFUPDATE_PATH" != "." ]; then
     # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::' | sed 's:/*$::')"
+    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::;s:/*$::')"
   fi
   echo "${STR}/terraform-v${VERSION}"
 }
@@ -15,7 +15,7 @@ function branchForProvider {
   STR=tfupdate
   if [ "$TFUPDATE_PATH" != "." ]; then
     # Trim $TFUPDATE_PATH to remove leading and trailing slashes ("/")
-    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::' | sed 's:/*$::')"
+    STR="$STR/$(echo "$TFUPDATE_PATH" | sed 's:^/*::;s:/*$::')"
   fi
   echo "${STR}/terraform-provider/${TFUPDATE_PROVIDER_NAME}-v${VERSION}"
 }
@@ -29,8 +29,8 @@ function subcommandTerraform {
   if [ "$PR_COUNT" -ne 0 ]; then
     echo "A pull request already exists for branch ${VERSION_BRANCH}"
   else
-    git checkout -b "${VERSION_BRANCH}" origin/${PR_BASE_BRANCH}
-    tfupdate terraform -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
+    git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
+    tfupdate terraform -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
 
     git add .
     if git diff --cached --exit-code --quiet; then
@@ -38,7 +38,7 @@ function subcommandTerraform {
     else
       if [ "${UPDATE_TFENV_VERSION_FILES}" == "1" ]; then
         for UPDATED_HCL in $(git diff --cached --name-only); do
-          TFENV_VERSION_FILE="$(dirname $UPDATED_HCL)/.terraform-version"
+          TFENV_VERSION_FILE="$(dirname "$UPDATED_HCL")/.terraform-version"
           if [ -f "$TFENV_VERSION_FILE" ]; then
             echo "$VERSION" > "$TFENV_VERSION_FILE"
           fi
@@ -51,7 +51,7 @@ function subcommandTerraform {
 
       if [ "${UPDATE_TOOL_VERSIONS_FILES}" == "1" ]; then
         for UPDATED_HCL in $(git diff --cached --name-only); do
-          TOOL_VERSIONS_FILE="$(dirname $UPDATED_HCL)/.tool-versions"
+          TOOL_VERSIONS_FILE="$(dirname "$UPDATED_HCL")/.tool-versions"
           if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
             sed -i "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE"
           fi
@@ -83,8 +83,8 @@ function subcommandProvider {
   if [ "$PR_COUNT" -ne 0 ]; then
     echo "A pull request already exists for branch ${VERSION_BRANCH}"
   else
-    git checkout -b "${VERSION_BRANCH}" origin/${PR_BASE_BRANCH}
-    tfupdate provider ${TFUPDATE_PROVIDER_NAME} -v ${VERSION} ${TFUPDATE_OPTIONS} ${TFUPDATE_PATH}
+    git checkout -b "${VERSION_BRANCH}" "origin/${PR_BASE_BRANCH}"
+    tfupdate provider "${TFUPDATE_PROVIDER_NAME}" -v "${VERSION}" ${TFUPDATE_OPTIONS} "${TFUPDATE_PATH}"
     git add .
     if git diff --cached --exit-code --quiet; then
       echo "No changes"
@@ -97,7 +97,6 @@ function subcommandProvider {
       else
         gh pr create --title "$UPDATE_MESSAGE" --body "$PR_BODY" --base "${PR_BASE_BRANCH}"
       fi
-
     fi
   fi
 }
@@ -149,18 +148,12 @@ if [ "${INPUT_ASSIGNEES}" != "" ]; then
   ASSIGNEES=$(echo "${INPUT_ASSIGNEES}" | tr -d ' ')
 fi
 
-GITHUB_TOKEN=""
-if [ "${INPUT_GITHUB_TOKEN}" != "" ]; then
-  GITHUB_TOKEN=${INPUT_GITHUB_TOKEN}
-else
-  echo "github_token is required"
-  exit 1
-fi
+GITHUB_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 cd "${GITHUB_WORKSPACE}/"
 
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
-git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,13 +53,11 @@ function subcommandTerraform {
         for UPDATED_HCL in $(git diff --cached --name-only); do
           TOOL_VERSIONS_FILE="$(dirname $UPDATED_HCL)/.tool-versions"
           if [ -f "$TOOL_VERSIONS_FILE" ] && grep -q '^terraform ' "$TOOL_VERSIONS_FILE"; then
-            sed "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE" > "$TOOL_VERSIONS_FILE.tmp"
-            mv "$TOOL_VERSIONS_FILE.tmp" "$TOOL_VERSIONS_FILE"
+            sed -i "s/^terraform .*/terraform ${VERSION}/" "$TOOL_VERSIONS_FILE"
           fi
         done
         if [ -f ".tool-versions" ] && grep -q '^terraform ' ".tool-versions"; then
-          sed "s/^terraform .*/terraform ${VERSION}/" ".tool-versions" > ".tool-versions.tmp"
-          mv ".tool-versions.tmp" ".tool-versions"
+          sed -i "s/^terraform .*/terraform ${VERSION}/" ".tool-versions"
         fi
         git add .
       fi


### PR DESCRIPTION
- closes https://github.com/masutaka/tfupdate-github-actions/issues/7

## Summary

Convert Docker-based action (`minamijoyo/tfupdate` image) to a composite action that installs the tfupdate binary directly and replaces `hub` CLI with `gh` CLI.

### Changes

- **action.yml**: Convert from `runs.using: docker` to `runs.using: composite` with two steps — install tfupdate (with SHA-256 checksum verification) and run entrypoint
- **entrypoint.sh**:
  - Replace `hub` with `gh` CLI
  - Switch PR duplicate check from title-based to branch-based (`gh pr list --head`)
  - Harden shell settings (`set -euo pipefail`)
  - Strip spaces from assignees input
  - Extract common functions (`commitAndCreatePR`, `hasExistingPR`, `branchPrefix`) to reduce duplication
  - Pass all dependencies as function arguments to eliminate hidden state
  - Simplify `sed -i` (no backup suffix needed on Linux runners)
  - Rename PR body variable to `PR_BODY` for consistency
- **action.yml**: Make `github_token` optional with default `${{ github.token }}`
- **Dockerfile**: Removed (no longer needed)
- **README.md / README_ja.md**: Update PR deduplication description, change `runs-on` to `ubuntu-slim` in examples, remove "no spaces around the comma" constraint from assignees