### PR TITLE
fix: Check only open PRs to avoid blocking by closed unmerged PRs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ function branchForProvider {
 function hasExistingPR {
   local branch="$1"
   local pr_count
-  pr_count="$(gh pr list --state all --head "${branch}" --json number --jq 'length')"
+  pr_count="$(gh pr list --state open --head "${branch}" --json number --jq 'length')"
   [ "$pr_count" -ne 0 ]
 }
 


### PR DESCRIPTION
## Summary

- `hasExistingPR` used `gh pr list --state all`, which counted closed (unmerged) PRs as existing
- This permanently blocked recreation of the same version update PR after a PR was closed without merging
- Changed to `--state open` so only open PRs are checked

## Background

When a PR was closed without merging, `hasExistingPR` still detected it and skipped PR creation with the message "A pull request already exists for branch ...". This prevented the workflow from ever recreating a PR for that version.

With `--state open`, even if a PR for the same version was previously closed or merged, a new PR can be created. If the version is already applied (merged case), the existing `git diff --cached --exit-code --quiet` check will catch "No changes" and exit gracefully.