### PR TITLE
feat: Output created PR URL as annotation for better visibility in Actions runs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,13 +34,16 @@ function commitAndCreatePR {
   local base_branch="$3"
   local assignees="$4"
 
+  local pr_url
+
   git commit -m "$message"
   git push origin HEAD
   if [ -n "$assignees" ]; then
-    gh pr create --title "$message" --body "$body" --base "${base_branch}" --assignee "${assignees}"
+    pr_url=$(gh pr create --title "$message" --body "$body" --base "${base_branch}" --assignee "${assignees}")
   else
-    gh pr create --title "$message" --body "$body" --base "${base_branch}"
+    pr_url=$(gh pr create --title "$message" --body "$body" --base "${base_branch}")
   fi
+  echo "::notice::Created PR: ${pr_url}"
 }
 
 function subcommandTerraform {


### PR DESCRIPTION
## Summary

- Output the created PR URL as a GitHub Actions annotation (`::notice::`) so it appears in the Annotations section of workflow runs
