### PR TITLE
chore: Bump tfupdate to v0.9.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,8 @@ runs:
   steps:
     - name: Install tfupdate
       env:
-        TFUPDATE_VERSION: v0.9.3
-        TFUPDATE_SHA256: dfdc45648bb5e3efd4fb6e6e03fb672254041640116e2255380b5dfe7c01ff3a
+        TFUPDATE_VERSION: v0.9.4
+        TFUPDATE_SHA256: fbaecf2d6b4180792239076f917c35d12a8a67c7b223b8e9a36ab3852d4913e3
       run: |
         curl -fL --output "$RUNNER_TEMP/tfupdate.tar.gz" "https://github.com/minamijoyo/tfupdate/releases/download/${TFUPDATE_VERSION}/tfupdate_${TFUPDATE_VERSION#v}_linux_amd64.tar.gz"
         echo "${TFUPDATE_SHA256} $RUNNER_TEMP/tfupdate.tar.gz" | sha256sum -c -


### PR DESCRIPTION
- closes https://github.com/masutaka/tfupdate-github-actions/issues/17

## Summary

Bump `TFUPDATE_VERSION` to [`v0.9.4`](https://github.com/minamijoyo/tfupdate/releases/tag/v0.9.4) in `action.yml` and replace `TFUPDATE_SHA256` with the official checksum for `tfupdate_0.9.4_linux_amd64.tar.gz`.

## Notable upstream changes

- Add support for Terraform v1.15
- Add support for OpenTofu v1.11