### PR TITLE
chore: Bump tfupdate to v0.10.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,8 @@ runs:
   steps:
     - name: Install tfupdate
       env:
-        TFUPDATE_VERSION: v0.9.4
-        TFUPDATE_SHA256: fbaecf2d6b4180792239076f917c35d12a8a67c7b223b8e9a36ab3852d4913e3
+        TFUPDATE_VERSION: v0.10.1
+        TFUPDATE_SHA256: c7ea276e052f1090a87a093a5c852cd7a14ce4144486ee34641fc87e1a2151ab
       run: |
         curl -fL --output "$RUNNER_TEMP/tfupdate.tar.gz" "https://github.com/minamijoyo/tfupdate/releases/download/${TFUPDATE_VERSION}/tfupdate_${TFUPDATE_VERSION#v}_linux_amd64.tar.gz"
         echo "${TFUPDATE_SHA256} $RUNNER_TEMP/tfupdate.tar.gz" | sha256sum -c -


### PR DESCRIPTION
## Overview

Bump tfupdate from v0.9.4 to [v0.10.1](https://github.com/minamijoyo/tfupdate/releases/tag/v0.10.1).

This supersedes #19 (v0.10.0), since v0.10.1 is now the latest release.

## Changes

Updated the `Install tfupdate` step in `action.yml`.

- `TFUPDATE_VERSION`: `v0.9.4` -> `v0.10.1`
- `TFUPDATE_SHA256`: Updated to the linux_amd64 value from the official `checksums.txt` (verified by downloading the actual asset)

## Release notes review

No breaking changes between v0.9.4 and v0.10.1.

[v0.10.0](https://github.com/minamijoyo/tfupdate/releases/tag/v0.10.0):

- Add support for OpenTofu v1.12
- Skip downloading binaries if the registry supports h1 hashes (efficiency improvement)
- Internal API rename and lint fixes

[v0.10.1](https://github.com/minamijoyo/tfupdate/releases/tag/v0.10.1):

- Remove x/exp dependency and go fix
- Dependency updates (golang.org/x/net, golang.org/x/exp)

The CLI commands/options, asset filenames, and download URL format are all unchanged, so no changes to `entrypoint.sh` are required.
